### PR TITLE
Added two (pretty large) features. See description.

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -9,7 +9,58 @@ module.exports = {
   },
   formatChatData: function (data) {
     if (data.includes('[CHAT]') || data.includes('(shout)')) {
-      return data.slice((data.indexOf(']') + 2));
+      data = data.slice((data.indexOf(']') + 2)); //black magic fuckery as far as i'm concerned
+      if (data.includes('[')) {
+        //These all are for Factorio rich text fuckery, in order of https://wiki.factorio.com/Rich_text
+        //for now, the discord will show [image], [item], [gps] but that can be removed completely by just
+        //replacing the second phrase in the .replace with an empty string, i.e. ''
+        if (data.includes('[img=')) {
+          message.content = message.content.replace(/\[img=.*\]/g, '[image]');
+        }
+        if (data.includes('[item=')) {
+          message.content = message.content.replace(/\[item=.*\]/g, '[item]');
+        }
+        if (data.includes('[entity=')) {
+          message.content = message.content.replace(/\[entity=.*\]/g, '[entity]');
+        }
+        if (data.includes('[technology=')) {
+          message.content = message.content.replace(/\[technology=.*\]/g, '[research]');
+        }
+        if (data.includes('[recipe=')) {
+          message.content = message.content.replace(/\[recipe=.*\]/g, '[recipe]');
+        }
+        if (data.includes('[item-group=')) {
+          message.content = message.content.replace(/\[item-group=.*\]/g, '[item group]');
+        }
+        if (data.includes('[fluid=')) {
+          message.content = message.content.replace(/\[fluid=.*\]/g, '[fluid]');
+        }
+        if (data.includes('[tile=')) {
+          message.content = message.content.replace(/\[tile=.*\]/g, '[tile]');
+        }
+        if (data.includes('[virtual-signal=')) {
+          message.content = message.content.replace(/\[virutal-signal=.*\]/g, '[signal]');
+        }
+        if (data.includes('[achievement=')) {
+          message.content = message.content.replace(/\[achievement=.*\]/g, '[achievement]');
+        }
+        if (data.includes('[gps=')) {
+          message.content = message.content.replace(/\[gps=.*\]/g, '[gps]');
+        }
+        if (data.includes('[special-item=')) {
+          message.content = message.content.replace(/\[special-item=.*\]/g, '[bp/upgrade/decon]');
+        }
+        if (data.includes('[armor=')) {
+          message.content = message.content.replace(/\[armor=.*\]/g, '[armor]');
+        }
+        if (data.includes('[train=')) {
+          message.content = message.content.replace(/\[train=.*\]/g, '[train]')
+        }
+        if (data.includes('[train-stop=')) {
+          message.content = message.content.replace(/\[train-stop.*\]/g, '[train stop]');
+        }
+      }
+      return data;
     } else {
       return `**${data.slice((data.indexOf(']') + 2))}**`
     }

--- a/functions.js
+++ b/functions.js
@@ -9,9 +9,9 @@ module.exports = {
   },
   formatChatData: function (data) {
     if (data.includes('[CHAT]') || data.includes('(shout)')) {
-      data = data.slice((data.indexOf(']') + 2)); //black magic fuckery as far as i'm concerned
+      data = data.slice((data.indexOf(']') + 2)); //removing the [CHAT] from sending to Discord
       if (data.includes('[')) {
-        //These all are for Factorio rich text fuckery, in order of https://wiki.factorio.com/Rich_text
+        //These all are for Factorio rich text magic, in order of https://wiki.factorio.com/Rich_text
         //for now, the discord will show [image], [item], [gps] but that can be removed completely by just
         //replacing the second phrase in the .replace with an empty string, i.e. ''
         if (data.includes('[img=')) {

--- a/index.js
+++ b/index.js
@@ -75,12 +75,12 @@ client.on('message', (message) => {
   //checking for mentions and replacing the user/channel id with the name
   if (message.content.includes('<@')) { //check if the message that the bot reads has a mention of a user
     message.mentions.users.forEach(user => {
-      message.content = message.content.replace(/<@.*>/, '@'+user);
+      message.content = message.content.replace(/<@[\S.]*>/, '@'+user);
     });
   }
   if (message.content.includes('<#')) { //check if the message includes a mention of a discord channel
     message.mentions.channels.forEach(channel => {
-      message.content = message.content.replace(/<#.*>/, '#'+channel);
+      message.content = message.content.replace(/<#[\S.]*>/, '#'+channel);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const testTail = new Tail('../servers/test/server.out');
 const krastorioTail = new Tail('../servers/members-krastorio2/server.out');
 const spiderTail = new Tail('../servers/members-spidertron/server.out');
 
+//to be able to write into the game chat what happens on the discord server
 const chronoFifo = new FIFO('../servers/chronotrain/server.fifo');
 exports.chronoFifo = chronoFifo;
 const coreFifo = new FIFO('../servers/members-core/server.fifo');
@@ -65,8 +66,25 @@ client.on('ready', () => {
 
 client.on('message', (message) => {
   if (message.content.includes('Jammy say hi')) message.channel.send(':wave:');
-  if (message.author.bot) return
+  if (message.content.includes('Jammy, work for me') && message.author.name == 'oof2win2') {
+    message.channel.send('yes, master. anything for you, master oof2win2.')
+  }
+  if (message.author.bot) return;
   if (message.content.includes('lenny')) message.channel.send(`( ͡° ͜ʖ ͡°)`);
+
+  //checking for mentions and replacing the user/channel id with the name
+  if (message.content.includes('<@')) { //check if the message that the bot reads has a mention of a user
+    message.mentions.users.forEach(user => {
+      message.content = message.content.replace(/<@.*>/, '@'+user);
+    });
+  }
+  if (message.content.includes('<#')) { //check if the message includes a mention of a discord channel
+    message.mentions.channels.forEach(channel => {
+      message.content = message.content.replace(/<#.*>/, '#'+channel);
+    });
+  }
+
+  //phase of sending the message from discord to Factorio
   if (message.channel.id === '718056299501191189') {
     coreFifo.write(`${message.author.username}: ${message.content}`, () => { });
   }


### PR DESCRIPTION
When deployed, the game chat things such as [gps=..], [armor=..] will no longer appear in the Discord chat! They are removed using regex searches. Also, hopefully correctly, added a feature that should theoretically write the name of the user or channel mentioned on Discord into the Factorio chat rather than the channel or user IDs, making it more readable by humans.