### PR TITLE
Fix to make stats work

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ This bot is for integration of a Discord server and multiple Factorio servers. I
 
 ---
 To use JLOGGER features, please load the scenario from the `freeplay-jlogger` folder or copy its contents into an existing save. This will allow logging for features such as deaths, rocket launches and research.
+To include it in an existing save:
+so first: unzip the latest save
+second: get the `control.lua` and `scripts` from `/opt/factorio/AwF-Bot-Test/freeplay-jlogger`
+third: paste them into the unzipped save (replace default `control.lua` with the modified one
+fourth: zip back up and restore from that save (?restoresave works fine for that, you may need to start it up by connecting though)

--- a/commands/factorio/fstats.js
+++ b/commands/factorio/fstats.js
@@ -43,13 +43,13 @@ module.exports = {
                         `© ${message.guild.me.displayName} | Developed by DistroByte & oof2win2 | Total Commands: ${client.commands.size}`,
                         client.user.displayAvatarURL()
                     )
-                let rockets = await searchOneDB(message.channel.name, "stats", { rocketLaunches: { $exists: true } });
+                let rockets = await searchOneDB(args[0], "stats", { rocketLaunches: { $exists: true } });
                 if (rockets == null)
                     rockets = 0
                 else 
                     rockets = rockets.rocketLaunches
                 statsEmbed.addField('Rockets launched', rockets)
-                let research = await searchOneDB(message.channel.name, "stats", { completedResearch: { $exists: true } });
+                let research = await searchOneDB(args[0], "stats", { completedResearch: { $exists: true } });
                 research = research.completedResearch;
                 let maxLevelResearch = ["str", 0];
                 Object.keys(research).forEach(function (key) {

--- a/commands/factorio/fstats.js
+++ b/commands/factorio/fstats.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const Discord = require('discord.js')
-const { searchOneDB } = require('../../functions')
+const { searchOneDB, bubbleSort } = require('../../functions')
 
 module.exports = {
     config: {

--- a/commands/factorio/stopServer.js
+++ b/commands/factorio/stopServer.js
@@ -43,9 +43,25 @@ module.exports = {
                 }
 
                 try { // stop the server
-                    exec(absPath + '/' + args[0] + '/factorio-init/factorio stop');
+                    //this wasn't finishing last time
+                    let res = await new Promise((resolve, reject) => {
+                        exec(`${absPath}/${args[0]}/factorio-init/factorio stop`, (error, stdout, stderr) => {
+                            if (error) {
+                                console.log(error.message)
+                                reject(['error', error.message]);
+                            }
+                            if (stderr) {
+                                console.log(stderr)
+                                reject(['stderr', stderr]);
+                            }
+                            console.log(stdout)
+                            resolve(stdout);
+                        });
+                    })
+                    console.log(res);
+                    message.channel.send(`out: ${res[0]}: ${res[1]}`);
                 } catch (e) {
-                    return message.channel.send(`server restore: stop error: ${e}`);
+                    return message.channel.send(`61 server stop error: ${e}`);
                 }
 
                 return message.channel.send('Server stop success')


### PR DESCRIPTION
Fixed using `args[0]` instead of `message.channel.name` when searching for the statistics and also require `bubbleSort`