### PR TITLE
Fixed the bug in description

### DIFF
--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -11,13 +11,13 @@ module.exports = async (client, message) => {
     return message.channel.send(":wave:");
   if (message.content.includes("Jammy work"))
     return message.channel.send("you coded me this way, your issue");
-  if (message.content.includes("soon"))
+  if (message.content.toLowerCase().includes("soon"))
     message.react(
       message.guild.emojis.cache.find((emoji) => emoji.name === "soontm")
     );
-  if (message.content.includes("lenny"))
+  if (message.content.toLowerCase().includes("lenny"))
     return message.channel.send(`( ͡° ͜ʖ ͡°)`);
-  if (message.content.startsWith("slap")) {
+  if (message.content.toLowerCase().startsWith("slap")) {
     message.delete();
     return message.channel.send(
       `${

--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -17,7 +17,7 @@ module.exports = async (client, message) => {
     );
   if (message.content.includes("lenny"))
     return message.channel.send(`( ͡° ͜ʖ ͡°)`);
-  if (message.content.includes("slap") && message.mentions) {
+  if (message.content.startsWith("slap")) {
     message.delete();
     return message.channel.send(
       `${


### PR DESCRIPTION
This fixes the bug of text cutoff, where if there was ANY `slap` in a message, the message would get cut off and the `:slap:` emoji would be sent. This makes sure that the slap message is sent only if the message is `slap ..` or `SLAP ..`. For some other things, the message is changed to lower case before checking.